### PR TITLE
Release script and run tests in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,14 @@ configuration: Release
 environment:
   sourceFolder: src
   projectName: Client
+  solutionName: tdl.sln
   api_key:
     secure: ZewpmA+rJPVO5I9JfzSNV4h7B1Qk6tL+udqkmlRQbtUAvSXtj+XGCFFTs9fv4hkP
   packageName: TDL.Client
 
+install:
+- cmd: git submodule update --init --recursive
+  
 before_build:
 - ps: >-
     nuget restore
@@ -21,14 +25,20 @@ before_build:
     }
 
 build:
-  project: $(sourceFolder)\$(projectName)\$(projectName).csproj
+  project: $(solutionName)
   publish_nuget: true
   publish_nuget_symbols: true
   verbosity: minimal
 
+before_test:
+- ps: >-
+    cd broker
+
+    .\activemq-wrapper.ps1
+
 deploy_script:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe  
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") {($artifacts.values | Where-Object {($_.path -like '*.nupkg') -and  !($_.path -like '*.symbols.nupkg')}) | foreach-object {nuget.exe push $_.path -Source https://www.nuget.org/api/v2/package -ApiKey $env:api_key; if ($lastexitcode -ne 0) {throw}}    }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq "true" -and $end:APPVEYOR_REPO_TAG_NAME.StartsWith("v0.")) {($artifacts.values | Where-Object {($_.path -like '*.nupkg') -and  !($_.path -like '*.symbols.nupkg')}) | foreach-object {nuget.exe push $_.path -Source https://www.nuget.org/api/v2/package -ApiKey $env:api_key; if ($lastexitcode -ne 0) {throw}}    }
 
 # Use this instead of deploy_script when appveyor fixes it.
 #deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ before_build:
 - ps: >-
     nuget restore
 
-    if ($env:APPVEYOR_REPO_TAG -eq "true") {
+    if ($env:APPVEYOR_REPO_TAG -eq "true" -and $end:APPVEYOR_REPO_TAG_NAME.StartsWith("v0.")) {
       # Patch NuGet package version into .nuspec file
       $nuspecPath = "$env:APPVEYOR_BUILD_FOLDER\$env:sourceFolder\$env:projectName\$env:projectName.nuspec"
       $nuspec = [xml](Get-Content $nuspecPath)

--- a/release.ps1
+++ b/release.ps1
@@ -45,6 +45,7 @@ if ($answer -eq "y")
 	$releaseProperties.Save((Resolve-Path $releasePropertiesPath).Path)
 	
 	git stage $releasePropertiesPath
+	git commit -m"Update release version to $($newVersion)"
 	git tag -a "v$($newVersion)" -m "Release $($newVersion)"
 	git push origin "v$($newVersion)"
 	

--- a/release.ps1
+++ b/release.ps1
@@ -1,0 +1,52 @@
+git submodule update --init --recursive
+
+$releasePropertiesPath = "./release.xml"
+
+$releaseProperties = [xml](Get-Content $releasePropertiesPath)
+
+$previousVersion = $releaseProperties.previousVersion
+$previousVersionValues = $previousVersion.Split('.')
+$previousVersionMajor = $previousVersionValues[0]
+$previousVersionMinor = $previousVersionValues[1]
+$previousVersionPatch = $previousVersionValues[2]
+
+Write-Host "Previous version: $($previousVersion)"
+
+$clientPath = (Resolve-Path .\).Path
+
+cd test\specs\client
+
+$currentSpecsVerion = git describe --tags --abbrev=0
+
+$currentSpecsVerionValues = $currentSpecsVerion.Split('.')
+$currentSpecsVerionMajor = $currentSpecsVerionValues[0].Trim("v")
+$currentSpecsVerionMinor = $currentSpecsVerionValues[1]
+
+Write-Host "Current specs verion: $($currentSpecsVerion)"
+
+cd $clientPath
+
+$newVersionPatch = ""
+if ($previousVersionMajor -eq $currentSpecsVerionMajor -and $previousVersionMinor -eq $currentSpecsVerionMinor)
+{
+	$newVersionPatch = [string]([convert]::ToInt32($previousVersionPatch, 10) + 1)
+}
+else
+{
+	$newVersionPatch = "0"
+}
+
+$newVersion = "$($currentSpecsVerionMajor).$($currentSpecsVerionMinor).$($newVersionPatch)"
+
+$answer = Read-Host "Going to release version $($newVersion). Proceed? [y/n]"
+if ($answer -eq "y")	
+{
+	$releaseProperties.previousVersion = $newVersion;
+	$releaseProperties.Save((Resolve-Path $releasePropertiesPath).Path)
+	
+	git stage $releasePropertiesPath
+	git tag -a "v$($newVersion)" -m "Release $($newVersion)"
+	git push origin "v$($newVersion)"
+	
+	Write-Host "Pushed tag to Git origin. It will now trigger the deployment pipeline."
+}

--- a/release.ps1
+++ b/release.ps1
@@ -46,6 +46,7 @@ if ($answer -eq "y")
 	
 	git stage $releasePropertiesPath
 	git commit -m"Update release version to $($newVersion)"
+	git push
 	git tag -a "v$($newVersion)" -m "Release $($newVersion)"
 	git push origin "v$($newVersion)"
 	

--- a/release.xml
+++ b/release.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<previousVersion>0.14.4</previousVersion>

--- a/release.xml
+++ b/release.xml
@@ -1,2 +1,2 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<previousVersion>0.14.4</previousVersion>
+<previousVersion>0.14.6</previousVersion>

--- a/test/specs/Test.Specs.csproj
+++ b/test/specs/Test.Specs.csproj
@@ -64,12 +64,12 @@
     <Compile Include="Utils\Extensions\SpecFlowTableExtension.cs" />
     <Compile Include="Utils\Logging\LogAuditStream.cs" />
     <Compile Include="Utils\MimeType.cs" />
-    <Compile Include="client\*.feature.cs"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
-    <None Include="client\*.feature" />
+    <!-- Include all feature files from the specs folder. -->
+    <None Include="client\**\*.feature" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Client\Client.csproj">
@@ -80,6 +80,12 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\SpecFlow.2.2.1\tools\TechTalk.SpecFlow.targets" Condition="Exists('..\..\packages\SpecFlow.2.2.1\tools\TechTalk.SpecFlow.targets')" />
+  <Target Name="AfterUpdateFeatureFilesInProject">
+    <!-- Include any files that specflow generated into the compilation of the project. -->
+    <ItemGroup>
+      <Compile Include="@(SpecFlowGeneratedFiles)" />
+    </ItemGroup>
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/test/specs/Test.Specs.csproj
+++ b/test/specs/Test.Specs.csproj
@@ -51,11 +51,6 @@
     <Compile Include="CallImplementationFactory.cs" />
     <Compile Include="ClientActionsFactory.cs" />
     <Compile Include="ClientSteps.cs" />
-    <Compile Include="client\client.feature.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>client.feature</DependentUpon>
-    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SingletonTestBroker.cs" />
     <Compile Include="SpecItems\OutputSpecItem.cs" />
@@ -69,14 +64,12 @@
     <Compile Include="Utils\Extensions\SpecFlowTableExtension.cs" />
     <Compile Include="Utils\Logging\LogAuditStream.cs" />
     <Compile Include="Utils\MimeType.cs" />
+    <Compile Include="client\*.feature.cs"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="client\client.feature">
-      <Generator>SpecFlowSingleFileGenerator</Generator>
-      <LastGenOutput>client.feature.cs</LastGenOutput>
-    </None>
     <None Include="packages.config" />
+    <None Include="client\*.feature" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Client\Client.csproj">
@@ -86,6 +79,7 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\SpecFlow.2.2.1\tools\TechTalk.SpecFlow.targets" Condition="Exists('..\..\packages\SpecFlow.2.2.1\tools\TechTalk.SpecFlow.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>


### PR DESCRIPTION
Run release.ps1 script for release. It will take current version from `release.xml` and current spec version from client submodule. Dynamically compute new version from the version of the Spec and previous patch and push release tag to start auto deploy.